### PR TITLE
Workflow: Enable nightly deployment of Docker container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,8 @@ on:
       - master
     tags:
       - v*
+  schedule:
+    - cron: 0 7 * * *
   repository_dispatch:
     types: [run_build]
 


### PR DESCRIPTION
Previously, the `psp-pkgconf` Docker container was only set to be updated whenever a commit was made. The latest commit being from October 2021, means that packages are considerably out of date. This currently impacts `psp-pacman`, which, due to being built with an old OpenSSL version (`v1.1.1`, from Alpine `v3.14`), does not run on the main `pspdev` Docker image.